### PR TITLE
Maven: Use PaperSpigot repo directly instead of system scope dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,18 @@
 	<groupId>com.oneshotmc</groupId>
 	<artifactId>WhoNeedsPhysics</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+	<repositories>
+		<repository>
+			<id>PaperSpigot-Repo</id>
+			<url>http://ci.destroystokyo.com/plugin/repository/everything/</url>
+		</repository>
+	</repositories>
 	<dependencies>
 		<dependency>
 			<groupId>org.github.paperspigot</groupId>
 			<artifactId>paperspigot-api</artifactId>
 			<version>1.7.10-R0.1-SNAPSHOT</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/lib/PaperSpigot-API.jar</systemPath>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Use PaperSpigot repo directly instead of system scope dependency
If you're going to use Maven, use Maven ;)

Feel free to use a model for the rest of your plugins that use the system scope and a local jar dependency.
